### PR TITLE
fix(ui): provide GitLab state in project settings modal

### DIFF
--- a/apps/desktop/src/components/ProjectSettingsModalContent.svelte
+++ b/apps/desktop/src/components/ProjectSettingsModalContent.svelte
@@ -6,12 +6,32 @@
 	import GeneralSettings from '$components/projectSettings/GeneralSettings.svelte';
 	import iconsJson from '@gitbutler/ui/data/icons.json';
 	import type { ProjectSettingsModalState } from '$lib/state/uiState.svelte';
+	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
+	import { SECRET_SERVICE } from '$lib/secrets/secretsService';
+	import { GITLAB_CLIENT } from '$lib/forge/gitlab/gitlabClient.svelte';
+	import { GitLabState, GITLAB_STATE } from '$lib/forge/gitlab/gitlabState.svelte';
+	import { inject, provide } from '@gitbutler/core/context';
 
 	type Props = {
 		data: ProjectSettingsModalState;
 	};
 
 	const { data }: Props = $props();
+
+	// Provide GitLab state inside the modal scope so ForgeForm can persist values
+	const baseBranchService = inject(BASE_BRANCH_SERVICE);
+	const secretService = inject(SECRET_SERVICE);
+	const gitLabClient = inject(GITLAB_CLIENT);
+
+	const repoInfoResponse = $derived(baseBranchService.repo(data.projectId));
+	const repoInfo = $derived(repoInfoResponse.current.data);
+
+	$effect.pre(() => {
+		if (!repoInfo) return;
+		const gitLabState = new GitLabState(secretService, repoInfo, data.projectId);
+		provide(GITLAB_STATE, gitLabState);
+		gitLabClient.set(gitLabState);
+	});
 
 	const pages = [
 		{


### PR DESCRIPTION
Provide GitLab state and related services to the Project Settings modal so
ForgeForm can persist and access platform-specific values.

- inject BASE_BRANCH_SERVICE, SECRET_SERVICE and GITLAB_CLIENT for modal scope
- derive repoInfo from base branch service to obtain repository metadata
- create GitLabState with secrets and repo info and provide it as GITLAB_STATE
- set gitLabClient to the newly created GitLabState in the modal context

This fixes scoped state handling by ensuring GitLab-related state and client
are available inside the modal, enabling proper persistence and form behavior.